### PR TITLE
convert set-ent syntax in gitgub actions to environment files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "America/New_York"
+    labels:
+      - "actions"
+    assignees:
+      - "jeffsays"
+    reviewers:
+      - "jeffsays"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,19 +18,13 @@ jobs:
       - name: get current version and prior versions
         id: versions
         run: |
-          git tag --sort=-taggerdate > tags.txt
-          mostRecent=$(head -n1 tags.txt)
-          head -n2 tags.txt > latestTwo.txt
-          rm -f tags.txt latestTwo.txt
-          echo ::set-env name=mostRecentTag::$mostRecent
-          priorRelease=$(curl -s -H 'Authorization: token ${{ secrets.PRIOR_VERSION_TOKEN }}' -L https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
-          echo $priorRelease
-          echo ::set-env name=priorRelease::$priorRelease
+          echo "mostRecentTag=$(git tag --sort=-taggerdate | head -n1)" >> $GITHUB_ENV
+          echo "priorRelease=$(curl -s -H 'Authorization: token ${{ secrets.PRIOR_VERSION_TOKEN }}' -L https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)" >> $GITHUB_ENV
       - name: generate changelog
         id: changelog
         uses: charmixer/auto-changelog-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           output: changelog/changelog-${{ env.mostRecentTag }}.md
           base: changelog/HISTORY.md
           since_tag: ${{ env.priorRelease }}
@@ -45,7 +39,7 @@ jobs:
         run: cat changelog/changelog-${{ env.mostRecentTag }}.md
       - name: Create Release
         if: success()
-        uses: ncipollo/release-action@v1.5.0
+        uses: ncipollo/release-action@v1.7.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
@@ -54,7 +48,7 @@ jobs:
           commit: ${{ github.sha }}
           bodyFile: changelog/changelog-${{ env.mostRecentTag }}.md
       - name: commit & push
-        uses: github-actions-x/commit@v2.4
+        uses: github-actions-x/commit@v2.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-branch: master


### PR DESCRIPTION
## Summary
#### What does this PR do?
- removes usage of set-env syntax in github actions in favor of using newer environment files prior to deprecation deadline of nov 16
- adds dependabot configuration for keeping github action step versions up-to-date

## Details
#### Why did you make this change? What does it affect?
- set-env command being deprecated due to security flaw in github actions
