### PR TITLE
Allow longer lambda http client timeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,13 +217,13 @@ export default async function(options: Options) {
       return;
     }
     const MaxNumberOfMessages = 10;
-    const lambda = new AWS.Lambda({ region });
     const sqs = new AWS.SQS({ region });
     const now = new Date();
     const { Timeout, QueueUrl } =
       FunctionName != null
-        ? await getLambdaConfiguration(lambda, sqs, FunctionName)
+        ? await getLambdaConfiguration(new AWS.Lambda({ region }), sqs, FunctionName)
         : await getSqsConfiguration(sqs, primaryQueue);
+    const lambda = new AWS.Lambda({ region, httpOptions: { timeout: Timeout * 1000 + 1000 } });
 
     // Deadline for starting invocation
     const VisibilityTimeout = time - Timeout;


### PR DESCRIPTION
## Summary
Setup lambda client timeout to exceed the lambda function timeout

## Details
Avoid client timeout with synchronously invoking a lambda function with long timeout. The default client timeout is 2 minutes, but a lambda function timeout can be set as high as 15 minutes.
