### PR TITLE
Resolve CVE-2022-25883 - vulnerability in `semver`

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "flow-bin": "^0.112.0",
     "flow-copy-source": "^2.0.9",
-    "flow-typed": "^3.2.1",
+    "flow-typed": "^3.9.0",
     "git-describe": "^4.0.4",
     "jest": "^26.0.0",
     "license-checker": "^25.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,7 +1441,7 @@ __metadata:
     eslint-plugin-prettier: ^2.6.0
     flow-bin: ^0.112.0
     flow-copy-source: ^2.0.9
-    flow-typed: ^3.2.1
+    flow-typed: ^3.9.0
     git-describe: ^4.0.4
     jest: ^26.0.0
     license-checker: ^25.0.1
@@ -4510,9 +4510,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-typed@npm:^3.2.1":
-  version: 3.8.0
-  resolution: "flow-typed@npm:3.8.0"
+"flow-typed@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "flow-typed@npm:3.9.0"
   dependencies:
     "@octokit/rest": ^18.12.0
     colors: 1.4.0
@@ -4525,13 +4525,13 @@ __metadata:
     node-stream-zip: ^1.15.0
     prettier: ^1.19.1
     rimraf: ^3.0.2
-    semver: 7.3.2
+    semver: ^7.5.4
     table: ^6.7.3
     which: ^2.0.2
     yargs: ^15.1.0
   bin:
     flow-typed: dist/cli.js
-  checksum: f3b93888434b5b55613fcf13ede49c62c5541d70fdb06343ffe2f438b14e8aa34b5778df266679cf842efa1be8ebc75ca75f63a559e6cc7bc25eb5a337763b90
+  checksum: ec410b9dc1f979c3feee92258f9d5fc6087529991e4be0f4f8dd8e2af95d2903927f4bd37e032f9c50f3f21224bff08f8fb73dc5d3b7fd9ec4fcf43b75d42e08
   languageName: node
   linkType: hard
 
@@ -8353,51 +8353,31 @@ __metadata:
   linkType: hard
 
 "semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^5.6.0":
-  version: 5.7.1
-  resolution: "semver@npm:5.7.1"
+  version: 5.7.2
+  resolution: "semver@npm:5.7.2"
   bin:
-    semver: ./bin/semver
-  checksum: 57fd0acfd0bac382ee87cd52cd0aaa5af086a7dc8d60379dfe65fea491fb2489b6016400813930ecd61fd0952dae75c115287a1b16c234b1550887117744dfaf
-  languageName: node
-  linkType: hard
-
-"semver@npm:7.3.2":
-  version: 7.3.2
-  resolution: "semver@npm:7.3.2"
-  bin:
-    semver: bin/semver.js
-  checksum: 692f4900dadb43919614b0df9af23fe05743051cda0d1735b5e4d76f93c9e43a266fae73cfc928f5d1489f022c5c0e65dfd2900fcf5b1839c4e9a239729afa7b
+    semver: bin/semver
+  checksum: fb4ab5e0dd1c22ce0c937ea390b4a822147a9c53dbd2a9a0132f12fe382902beef4fbf12cf51bb955248d8d15874ce8cd89532569756384f994309825f10b686
   languageName: node
   linkType: hard
 
 "semver@npm:^6.0.0, semver@npm:^6.1.2, semver@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "semver@npm:6.3.0"
+  version: 6.3.1
+  resolution: "semver@npm:6.3.1"
   bin:
-    semver: ./bin/semver.js
-  checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
+    semver: bin/semver.js
+  checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
   languageName: node
   linkType: hard
 
-"semver@npm:^7.2.1, semver@npm:^7.3.2":
-  version: 7.3.5
-  resolution: "semver@npm:7.3.5"
+"semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: 5eafe6102bea2a7439897c1856362e31cc348ccf96efd455c8b5bc2c61e6f7e7b8250dc26b8828c1d76a56f818a7ee907a36ae9fb37a599d3d24609207001d60
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.3.5":
-  version: 7.5.0
-  resolution: "semver@npm:7.5.0"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: 2d266937756689a76f124ffb4c1ea3e1bbb2b263219f90ada8a11aebebe1280b13bb76cca2ca96bdee3dbc554cbc0b24752eb895b2a51577aa644427e9229f2b
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
## What does this PR do?
bump `flow-typed` to resolve CVE-2022-25883


# Details
## Why did you make this change? What does it affect?
resolve security vulnerability

# Testing
## How can the other reviewers check that your change works?
build should pass

```zsh
   └─ semver@npm:5.7.2 (via npm:2 || 3 || 4 || 5)
│  └─ semver@npm:5.7.2 (via npm:2 || 3 || 4 || 5)
│  └─ semver@npm:5.7.2 (via npm:^5.3.0)
│  └─ semver@npm:5.7.2 (via npm:^5.4.1)
│  └─ semver@npm:5.7.2 (via npm:^5.5.0)
│  └─ semver@npm:5.7.2 (via npm:^5.6.0)
│  └─ semver@npm:6.3.1 (via npm:^6.0.0)
│  └─ semver@npm:6.3.1 (via npm:^6.1.2)
│  └─ semver@npm:6.3.1 (via npm:^6.3.0)
│  └─ semver@npm:7.5.4 (via npm:^7.2.1)
│  └─ semver@npm:7.5.4 (via npm:^7.3.2)
│  └─ semver@npm:7.5.4 (via npm:^7.3.5)
│  └─ semver@npm:7.5.4 (via npm:^7.5.4)

```

| affected version(s) | patched version |
|-|-|
| < 5.7.2 | 5.7.2 |
| >= 6.0.0, < 6.3.1 | 6.3.1 |
| >= 7.0.0, < 7.5.2 | 7.5.2 |