### PR TITLE
remove issue auto assign on issues created

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -5,5 +5,5 @@ on:
 jobs:
   assignAuthor:
     name: Assign author
-    uses: CumulusDS/workflows/.github/workflows/assign.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/assign.yml@master
     secrets: inherit

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,14 +1,9 @@
 name: Assigner
 on:
-  issues:
-    types: [opened, reopened]
   pull_request_target:
     types: [opened, reopened]
 jobs:
   assignAuthor:
     name: Assign author
-    runs-on: ubuntu-20.04
-    timeout-minutes: 5
-    steps:
-      - name: assign
-        uses: technote-space/assign-author@v1
+    uses: CumulusDS/workflows/.github/workflows/assign.yml@master
+    secrets: inherit


### PR DESCRIPTION
# Summary
## What does this PR do?
stops auto-assignment of issues upon creation

# Details
## Why did you make this change? What does it affect?
noted during standup that we have some incorrect issue assignments due to the overzealous auto-assign workflow

# Testing
## How can the other reviewers check that your change works?
open an issue and boom, no more auto-assignment