### PR TITLE
chore: use shared workflows in place of deprecated `ubuntu-20.04` images

### DIFF
--- a/.github/workflows/labels_import.yml
+++ b/.github/workflows/labels_import.yml
@@ -1,49 +1,12 @@
 name: Import Labels
-
 on:
   label:
     types:
       - created
       - edited
       - deleted
-
 jobs:
   import:
     name: Import Labels
-    runs-on: ubuntu-20.04
-    timeout-minutes: 3
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Import between existing labels
-        uses: b4b4r07/github-labeler@master
-        with:
-          import: 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        id: cpr
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Import existing labels"
-          title: "Import existing labels"
-          body: |
-            ## Summary
-            #### What does this PR do?
-            - Syncs update of labels in repo to labels.yml
-
-            ## Details
-            #### Why did you make this change? What does it affect?
-            - Current labels.yaml and existing labels don't match.
-          branch: import-labels
-          branch-suffix: timestamp
-          delete-branch: true
-          reviewers: ${{ GITHUB.ACTOR }}
-          labels: automation
-      - name: Check outputs
-        run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+    uses: CumulusDS/workflows/.github/workflows/labels-import.yml@master
+    secrets: inherit

--- a/.github/workflows/labels_sync.yml
+++ b/.github/workflows/labels_sync.yml
@@ -1,24 +1,12 @@
 name: Sync Labels
-
 on:
   push:
     branches:
       - master
     paths:
       - .github/labels.yml
-
 jobs:
   sync:
     name: Sync Labels
-    runs-on: ubuntu-20.04
-    timeout-minutes: 3
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Sync Labels
-        uses: b4b4r07/github-labeler@master
-        id: labeler
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: CumulusDS/workflows/.github/workflows/labels-sync.yml@master
+    secrets: inherit


### PR DESCRIPTION
# Summary
## What does this PR do?
- Closes #99 
  - stops using `ubuntu-20.04` runners
  - uses shared workflows where applicable

# Details
## Why did you make this change? What does it affect?
- `ubuntu-20.04` runners will no longer work after 2025.04.01
- shared workflows have the runner set in them, so only need to manage in one spot

# Testing
## How can the other reviewers check that your change works?
Build should be 🟢 